### PR TITLE
chore(terragrunt): format check after latest ugprade.

### DIFF
--- a/tf-check/entrypoint.sh
+++ b/tf-check/entrypoint.sh
@@ -14,4 +14,4 @@ echo 'Checking OpenTofu files...'
 tofu fmt -check -recursive
 
 echo 'Checking Terragrunt files...'
-terragrunt hclfmt --terragrunt-check
+terragrunt hcl fmt -check


### PR DESCRIPTION
```sh
10:54:28.604 WARN   The `hclfmt` command is deprecated and will be removed in a future version of Terragrunt. Use `terragrunt hcl format` instead.
10:54:28.605 ERROR  flag provided but not defined: -terragrunt-check
```